### PR TITLE
fix Xenium parquet loading

### DIFF
--- a/sainsc/io/_io.py
+++ b/sainsc/io/_io.py
@@ -251,11 +251,14 @@ def read_Xenium(
         if "is_gene" in transcripts.collect_schema().names():
             transcripts = transcripts.filter(pl.col("is_gene"))
 
-        transcripts = (
-            transcripts.select(columns)
-            .with_columns(pl.col("feature_name").cast(pl.Categorical))
-            .collect()
-        )
+        with pl.StringCache():
+            transcripts = (
+                transcripts.select(columns)
+                .with_columns(
+                    pl.col("feature_name").cast(pl.String).cast(pl.Categorical)
+                )
+                .collect()
+            )
     else:
         transcripts = pl.read_csv(
             filepath,


### PR DESCRIPTION
Fix loading of Xenium parquet files by first converting to String and then Categorical