### PR TITLE
Improve signature calculation efficiency

### DIFF
--- a/sainsc/utils/_signatures.py
+++ b/sainsc/utils/_signatures.py
@@ -43,7 +43,4 @@ def celltype_signatures(
             mean_X_group.A1 if isinstance(mean_X_group, np.matrix) else mean_X_group
         )
 
-    signatures_df = pd.DataFrame(signatures, index=adata.var_names)
-    signatures_df /= signatures_df.sum(axis=0)
-
-    return signatures_df
+    return pd.DataFrame(signatures, index=adata.var_names)

--- a/sainsc/utils/_signatures.py
+++ b/sainsc/utils/_signatures.py
@@ -34,7 +34,7 @@ def celltype_signatures(
         :py:class:`pandas.DataFrame` of gene expression aggregated per 'cell type'.
     """
     X = adata.X if layer is None else adata.layers[layer]
-    grouping = adata.obs.groupby(celltype_col, observed=True).indices
+    grouping = adata.obs.groupby(celltype_col, observed=True, sort=False).indices
 
     signatures: dict[Any, np.ndarray] = {}
     for name, indices in grouping.items():

--- a/sainsc/utils/_signatures.py
+++ b/sainsc/utils/_signatures.py
@@ -1,7 +1,9 @@
-from collections.abc import Callable
+from typing import Any
 
 import anndata as ad
+import numpy as np
 import pandas as pd
+from numpy.typing import DTypeLike
 
 
 def celltype_signatures(
@@ -9,13 +11,10 @@ def celltype_signatures(
     *,
     celltype_col: str = "leiden",
     layer: str | None = None,
-    agg_method: str | Callable = "mean",
+    dtype: DTypeLike = np.float32,
 ) -> pd.DataFrame:
     """
-    Calculate gene expression signatures per 'celltype'.
-
-    Note, that this will make a dense copy of `adata.X` or the selected `layer`,
-    therefore potentially leading to large memory usage.
+    Calculate gene expression signatures per 'cell type'.
 
     Parameters
     ----------
@@ -24,25 +23,27 @@ def celltype_signatures(
         Name of column in :py:attr:`anndata.AnnData.obs` containing cell-type
         information.
     layer : str, optional
-        Which layer to use for aggregation. If `None`, `adata.X` is used.
-    agg_method : str or collections.abc.Callable, optional
-        Function to aggregate gene expression per cluster used by
-        :py:meth:`pandas.DataFrame.agg`.
+        Which :py:attr:`anndata.AnnData.layers` to use for aggregation. If `None`,
+        :py:attr:`anndata.AnnData.X` is used.
+    dytpe : numpy.typing.DTypeLike
+        Data type to use for the signatures.
 
     Returns
     -------
     pandas.DataFrame
-        :py:class:`pandas.DataFrame` of gene expression aggregated per 'celltype'.
+        :py:class:`pandas.DataFrame` of gene expression aggregated per 'cell type'.
     """
-    signatures = (
-        adata.to_df(layer=layer)
-        .merge(adata.obs[celltype_col], left_index=True, right_index=True)
-        .groupby(celltype_col, observed=True, sort=False)
-        .agg(agg_method)
-        .transpose()
-        .rename_axis(adata.var_names.name)
-    )
+    X = adata.X if layer is None else adata.layers[layer]
+    grouping = adata.obs.groupby(celltype_col, observed=True).indices
 
-    signatures /= signatures.sum(axis=0)
+    signatures: dict[Any, np.ndarray] = {}
+    for name, indices in grouping.items():
+        mean_X_group = X[indices].mean(axis=0, dtype=dtype)
+        signatures[name] = (
+            mean_X_group.A1 if isinstance(mean_X_group, np.matrix) else mean_X_group
+        )
 
-    return signatures
+    signatures_df = pd.DataFrame(signatures, index=adata.var_names)
+    signatures_df /= signatures_df.sum(axis=0)
+
+    return signatures_df

--- a/sainsc/utils/_signatures.py
+++ b/sainsc/utils/_signatures.py
@@ -1,4 +1,4 @@
-from typing import Any
+from collections.abc import Hashable
 
 import anndata as ad
 import numpy as np
@@ -36,7 +36,7 @@ def celltype_signatures(
     X = adata.X if layer is None else adata.layers[layer]
     grouping = adata.obs.groupby(celltype_col, observed=True, sort=False).indices
 
-    signatures: dict[Any, np.ndarray] = {}
+    signatures: dict[Hashable, np.ndarray] = {}
     for name, indices in grouping.items():
         mean_X_group = X[indices].mean(axis=0, dtype=dtype)
         signatures[name] = (


### PR DESCRIPTION
Improve efficiency of signature calculation by not making a dense copy (i.e. DataFrame) of the (scaled) count matrix.

The method becomes less flexible as the aggregation function can not be chosen anymore but will always be the mean.

Furthermore, signatures are not normalized per cluster anymore.