### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.10"
-    rust: "1.78"
+    rust: latest
 sphinx:
   configuration: docs/source/conf.py
 python:


### PR DESCRIPTION
ReadTheDocs was using outdated Rust version so that some dependencies could not be installed.

Not sure why not an older version of the dependency was used.

Using latest rust version and OS to hopefully avoid issues in the future