### PR TITLE
Remove deprecated macos-13 GitHub Action runner

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 and up is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -30,9 +29,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
-        env:
-          CIBW_ENVIRONMENT: ${{ matrix.os == 'macos-13' && 'MACOSX_DEPLOYMENT_TARGET=13.0' || '' }}
-          CIBW_ENVIRONMENT_LINUX: 'PATH=$PATH:$HOME/.cargo/bin'
 
       - uses: actions/upload-artifact@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,4 @@ skip = "pp*" # skip PyPy
 [tool.cibuildwheel.linux]
 # cibuildwheel runs linux in containers so we need to install rust there
 before-all = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+environment = { PATH = "$PATH:$HOME/.cargo/bin" }


### PR DESCRIPTION
The GitHub Action runner macos-13 has been deprecated since Dec 2025.
Binaries for Apple with Intel silicon will no longer be provided.