### PR TITLE
Switch to ABI3 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ num           = { version = "0.4.1" }
 numpy         = { version = "0.27" }
 polars        = { version = "0.53", features = ["partition_by", "dtype-categorical"] }
 polars-arrow  = { version = "0.53" }
-pyo3          = { version = "0.27", features = ["extension-module"] }
+pyo3          = { version = "0.27", features = ["extension-module", "abi3"] }
 pyo3-polars   = { version = "0.26", features = ["dtype-categorical"] }
 rayon         = { version = "1.8" }
 sprs          = { version = "0.11.4", features = ["serde"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ include = ["sainsc", "sainsc.io", "sainsc.lazykde", "sainsc.utils"]
 [tool.setuptools_scm]
 
 [[tool.setuptools-rust.ext-modules]]
-target = "sainsc._utils_rust"
+target         = "sainsc._utils_rust"
+py_limited_api = true
 
 
 [tool.ruff]
@@ -95,10 +96,10 @@ ignore-words-list = "coo,crate"
 
 [tool.cibuildwheel]
 archs = 'auto64'
-# build = 'cp310-*'
+build = 'cp311-*' # only build minimum python version because we use ABI3 builds
 skip = "pp*" # skip PyPy
 
 [tool.cibuildwheel.linux]
 # cibuildwheel runs linux in containers so we need to install rust there
-before-all = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
+before-all  = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = { PATH = "$PATH:$HOME/.cargo/bin" }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+# replace with minimum Python version (used for ABI3)
+py_limited_api = cp311


### PR DESCRIPTION
Switch to ABI3 builds to reduce the number of binaries generated when building the wheel