### PR TITLE
Adjust supported architectures

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,7 +15,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-latest
+          - macos-26-intel
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,7 @@ skip  = "pp*"     # skip PyPy
 # cibuildwheel runs linux in containers so we need to install rust there
 before-all  = "curl -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = { PATH = "$PATH:$HOME/.cargo/bin" }
+
+[tool.cibuildwheel.macos]
+# build for compatibility with macOS 11 and upwards
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,9 @@ plugins                = "numpy.typing.mypy_plugin"
 ignore-words-list = "coo,crate"
 
 [tool.cibuildwheel]
-archs = 'auto64'
-build = 'cp311-*' # only build minimum python version because we use ABI3 builds
-skip = "pp*" # skip PyPy
+archs = "auto64"
+build = "cp311-*" # only build minimum python version because we use ABI3 builds
+skip  = "pp*"     # skip PyPy
 
 [tool.cibuildwheel.linux]
 # cibuildwheel runs linux in containers so we need to install rust there


### PR DESCRIPTION
- Build additional binaries for macOS Intel and Linux ARM
- Set the macOS deployment target to control the downward compatibility of the binaries 