### PR TITLE
ABI3 only for cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,7 @@ include = ["sainsc", "sainsc.io", "sainsc.lazykde", "sainsc.utils"]
 [tool.setuptools_scm]
 
 [[tool.setuptools-rust.ext-modules]]
-target         = "sainsc._utils_rust"
-py_limited_api = true
+target = "sainsc._utils_rust"
 
 
 [tool.ruff]
@@ -98,6 +97,9 @@ ignore-words-list = "coo,crate"
 archs = "auto64"
 build = "cp311-*" # only build minimum python version because we use ABI3 builds
 skip  = "pp*"     # skip PyPy
+
+[tool.cibuildwheel.config-settings]
+--build-option = "--py-limited-api=cp311"
 
 [tool.cibuildwheel.linux]
 # cibuildwheel runs linux in containers so we need to install rust there

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-# replace with minimum Python version (used for ABI3)
-py_limited_api = cp311


### PR DESCRIPTION
use the ABI3 builds only for cibuildwheel but not when installing the package normally